### PR TITLE
Fix #5 - harmonic mean throws exception when given a set of zero values

### DIFF
--- a/src/bear.erl
+++ b/src/bear.erl
@@ -146,6 +146,9 @@ arithmetic_mean(#scan_result{n=N, sumX=Sum}) ->
 geometric_mean(#scan_result{n=N, sumLog=SumLog}) ->
     math:exp(SumLog/N).
 
+harmonic_mean(#scan_result{sumInv=0}) ->
+    %% Protect against divide by 0 if we have all 0 values
+    0;
 harmonic_mean(#scan_result{n=N, sumInv=Sum}) ->
     N/Sum.
 


### PR DESCRIPTION
This is the simple fix for this - it defines harmonic_mean to be 0 when the sum of inverses is 0, and avoids the bad_arith exception.
