### PR TITLE
Add math_log/1 and inverse/1 patterns to catch 0.0

### DIFF
--- a/src/bear.erl
+++ b/src/bear.erl
@@ -317,12 +317,16 @@ foldl2(_F, Acc, [], []) ->
 %% wrapper for math:log/1 to avoid dividing by zero
 math_log(0) ->
     1;
+math_log(0.0) ->
+    1.0;
 math_log(X) ->
     math:log(X).
 
 %% wrapper for calculating inverse to avoid dividing by zero
 inverse(0) ->
     0;
+inverse(0.0) ->
+    0.0;
 inverse(X) ->
     1/X.
 


### PR DESCRIPTION
inverse/1 bombs on 0.0.

```
1> bear:scan_values([0.039,0.001,0.00,0.028]).
** exception error: an error occurred when evaluating an arithmetic expression
     in function  bear:scan_values/2
     in call from lists:zip/2
```
