### PR TITLE
Add {modules, []} to bear.app.src

### DIFF
--- a/src/bear.app.src
+++ b/src/bear.app.src
@@ -4,5 +4,6 @@
   {vsn, git},
   {registered, []},
   {applications, []},
-  {env, []}
+  {env, []},
+  {modules, []}
  ]}.


### PR DESCRIPTION
erlang.mk complains otherwise and thus cannot build a release.
